### PR TITLE
Owner Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,35 +24,82 @@ route53 and gcloud DNS), which reconcile the provided zone
 content with the running zone.
 
 Template can use the comments on a DNS record to pass hints to the
-provisioner. 
+provisioner.
 
-At present it will only manage records that discoveres find, selective
-purging of records may be available in future.
+Dubber will only delete records under the following two circumstances:
+- A record of the same Name, Class, RR Type and Grouping Flag values (see below), already
+  exists, and has a different value.
+- No records of the same Name, Class, RR Type and Grouping Flag values (see below), were
+  request, and all the flags mentioned in the ownerFlags in the provisioner configuration
+  are set, and match the configured regexp of each flag.
+
+So by settings some grouping flag on a record, (e.g. route53.SetID), to a value that can be
+specific to a given instance of dubber, you can then allow dubber to delete records that match
+that specific value, if they are no longer needed.
+
+## Record Flags
+
+Dubber uses DNS comments to translate into non-traditional DNS options supported by the provisioners.
+Some flags are used to group records so that conflicting records within a group can be remove/replaced,
+but conflicting records in different groups are treated a separate entitied.
+
+### route53
+
+- `route53.SetID`: (Grouping Flag)  Associate these records with a Set
+- `route53.Weight`: Set a weight for the set
+- `route53.Alias`: "HOSTEDZONEID:ALIASNAME"
+- `route53.EvalTargetHealth`: "true" will enable target health evaluation
+
+### GCloud DNS
+
+TBD
 
 ## An example
 
 ```
 discoverers:
+  kubernetes:
+    - template: |
+      {{ $cluster := env `CLUSTER` }}
+      ; From Ingresses
+      {{- range $ing := .Ingresses }}
+        {{- $setID := or (index $ing.ObjectMeta.Labels `route53SetId`) $cluster }}
+        {{- $weight := or (index $ing.ObjectMeta.Labels `route53Weight`) `0` }}
+        {{- if len $ing.Status.LoadBalancer.Ingress }}
+        {{-   $sing := index $ing.Status.LoadBalancer.Ingress 0 }}
+        {{-   range $rule := $ing.Spec.Rules }}
+        {{-     if $rule.Host }}
+        {{-       if $sing.IP }}
+      {{ $rule.Host }} 60 A {{$sing.IP}}; route53.SetID={{ $setID }} route53.Weight={{ $weight }}
+        {{-       else }}
+      {{ $rule.Host }} CNAME {{ $sing.Hostname }};
+        {{-       end }}
+        {{-     end }}
+        {{-   end }}
+        {{- end  }}
+      {{- end }}
   marathon:
     - endpoints:
       -  http://marathon.mesos.example.com/api
       template: |
-        {{- $publicLB := "Z1234:dualstack.exanple-public.elb.amazonaws.com."}}
-        {{- $privateLB := "Z1234:dualstack.exanple-private.elb.amazonaws.com."}}
-        {{- range .Applications }} 
-        {{- if (index .Labels "dnsName") }}
-        {{- if eq (index .Labels "externalAccess") "public" }}
-        {{ index .Labels "dnsName"}} 0 A 0.0.0.0 ; route53.Alias={{$publicLB}}
-        {{- else }}
-        {{ index .Labels "dnsName"}} 0 A 0.0.0.0 ; route53.Alias={{$privateLB}}
-        {{- end }}
-        {{- end }}
+        {{- $publicLB := `Z1234:dualstack.exanple-public.elb.amazonaws.com.`}}
+        {{- $privateLB := `Z1234:dualstack.exanple-private.elb.amazonaws.com.`}}
+        {{- range .Applications }}
+        {{-   if (index .Labels `dnsName`) }}
+        {{-     if eq (index .Labels `externalAccess`) `public` }}
+        {{ index .Labels `dnsName`}} 0 A 0.0.0.0 ; route53.Alias={{$publicLB}}
+        {{-     else }}
+        {{ index .Labels `dnsName`}} 0 A 0.0.0.0 ; route53.Alias={{$privateLB}}
+        {{-     end }}
+        {{-   end }}
         {{- end }}
 
 provisioners:
   route53:
     - zone: example.com.
       zoneid: Z56789
+      ownerFlags:
+        "route53.SetID": "{{ env `CLUSTER` }}"
 ```
 
 Will create a route53 alias record, based on the dnsName and externalAccess
@@ -63,10 +110,10 @@ created for different elements.
 
 # TODO
 - Watch rather than poll
-- Selective poll interval
-- Purging
 - Possibly unify all data and pass it to a single template, rather than each
   discoverer having it's own template.
-- Functions to help build the records.
+- Template functions to help build the records.
+- Purging - possibly track the state of the records and allow purging of anything
+  we created (this is somewhat achievable via the ownerFlags)
 
 

--- a/provisioner.go
+++ b/provisioner.go
@@ -172,7 +172,7 @@ func (p dryRunProvisioner) RemoteZone() (Zone, error) {
 }
 
 func (p dryRunProvisioner) UpdateZone(allWanted, allUnwanted, desired, remote Zone) error {
-	klog.V(1).Info("Unwanted records to be removed:\n", allUnwanted)
-	klog.V(1).Info("Wanted records to be added:\n", allWanted)
+	klog.V(0).Info("Unwanted records to be removed:\n", allUnwanted)
+	klog.V(0).Info("Wanted records to be added:\n", allWanted)
 	return nil
 }

--- a/provisioner.go
+++ b/provisioner.go
@@ -16,6 +16,7 @@ package dubber
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/miekg/dns"
@@ -33,17 +34,18 @@ type Provisioner interface {
 	RemoteZone() (Zone, error)
 	UpdateZone(wanted, unwanted, desired, remote Zone) error
 	GroupFlags() []string
+	OwnerFlags() (map[string]*regexp.Regexp, error)
 }
 
 // ReconcileZone attempts to ensure that the set of records in the desired
 // zone are present in the Provisioner's zone.
-// - Records are grouped by Name.
-// - Records from the provisioner that are not listed in the desired set
-//   are ignored.
-// - Records of a given "Name, Type , Class" combination that are in the
-//   remote zone, but not in the desired zone are removed.
-// - Records of a given "Name, Type , Class" combination that are in the
-//   desired zone, but not in the remote zone are added.
+//   - Records are grouped by Name.
+//   - Records from the provisioner that are not listed in the desired set
+//     are ignored.
+//   - Records of a given "Name, Type , Class" combination that are in the
+//     remote zone, but not in the desired zone are removed.
+//   - Records of a given "Name, Type , Class" combination that are in the
+//     desired zone, but not in the remote zone are added.
 func (srv *Server) ReconcileZone(p Provisioner, desired Zone) error {
 	remz, err := p.RemoteZone()
 	if err != nil {
@@ -97,6 +99,44 @@ func (srv *Server) ReconcileZone(p Provisioner, desired Zone) error {
 		allWanted = append(allWanted, wanted...)
 	}
 
+	// unused remote groups
+	var unusedGroups []RecordSetKey
+	for rgroupKey := range rgroups {
+		_, ok := dgroups[rgroupKey]
+		if ok {
+			continue
+		}
+		// We can ignore the error here because this string
+		// was produced by us and so should always be valid
+		fs, _ := ParseRecordFlags(rgroupKey.GroupFlags)
+		matches := 0
+
+		// We can ignore the error here because we've already
+		// parsed these from config
+		oflags, _ := p.OwnerFlags()
+		if len(oflags) == 0 {
+			continue
+		}
+		for k, rx := range oflags {
+			for fk, fv := range fs {
+				if k != fk {
+					continue
+				}
+				if rx.MatchString(fv) {
+					matches += 1
+				}
+			}
+		}
+		if matches != 0 && matches == len(oflags) {
+			unusedGroups = append(unusedGroups, rgroupKey)
+		}
+	}
+
+	for _, unusedGroupKey := range unusedGroups {
+		rgroup := Zone(ByRR(rgroups[unusedGroupKey]).Dedupe())
+		allUnwanted = append(allUnwanted, rgroup...)
+	}
+
 	if len(allWanted) == 0 && len(allUnwanted) == 0 {
 		klog.V(1).Info("nothing to do")
 		return nil
@@ -121,6 +161,10 @@ type dryRunProvisioner struct {
 
 func (p dryRunProvisioner) GroupFlags() []string {
 	return p.real.GroupFlags()
+}
+
+func (p dryRunProvisioner) OwnerFlags() (map[string]*regexp.Regexp, error) {
+	return p.real.OwnerFlags()
 }
 
 func (p dryRunProvisioner) RemoteZone() (Zone, error) {

--- a/zone.go
+++ b/zone.go
@@ -415,7 +415,7 @@ func (z Zone) Group(groupFlags []string) map[RecordSetKey]Zone {
 		var flags []string
 		for _, f := range groupFlags {
 			if v, ok := rr.Flags[f]; ok {
-				flags = append(flags, fmt.Sprintf("%s=%q", f, v))
+				flags = append(flags, fmt.Sprintf("%s=%s", f, v))
 			}
 		}
 		k := RecordSetKey{


### PR DESCRIPTION
Allow a set of regexps that define, based on RR record comment tags, the
records that this dubber instance owns.

If all the configured regexps for a provisioner match a record, and that
record is present in the remote provisioner zone, but is not wanted by the
current discovery scrap, dubber will be allowed to delete the record.